### PR TITLE
Kubernetes version bump

### DIFF
--- a/.script/set-hostname-kmaster.sh
+++ b/.script/set-hostname-kmaster.sh
@@ -1,0 +1,17 @@
+############################################################# PLAY WITH KUBECTL #############################################################################
+#       Setting up hostname as kmaster
+#       system compatible: Ubuntu:18.04.5 LTS (Bionic Beaver) and 20.04.1 LTS (Focal Fossa).     
+#       Maintainer: Adil Abdullah Khan  
+#       To Run this script:
+#       curl  https://raw.githubusercontent.com/adil1806/play-with-kubectl/master/kubernetes-installation/set-hostname-kmaster.sh | bash
+#############################################################################################################################################################
+
+#!/bin/bash
+
+echo "[TASK 1] Setting hostname for this node to Kmaster"
+hostnamectl set-hostname kmaster >/dev/null 2>&1
+
+echo "[TASK 2] Adding newly created hostname to hosts file"
+sed -i 's/^127.0.0.1 .*/127.0.0.1 localhost kmaster/' hosts >/dev/null 2>&1
+
+echo "[Task 3] Please restart/reboot this system by ourself"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,8 +2,8 @@
 # ansible_user: root
 
 # Kubernetes
-#kube_version('v1.19.2', 'v1.20.4', 'v1.20.5')
-kube_version: v1.20.5
+#kube_version('v1.19.x', 'v1.20.x', 'v1.21.x')
+kube_version: v1.21.0
 token: b0f7b8.8d1767876297d85c
 
 # 1.8.x feature: --feature-gates SelfHosting=true
@@ -47,7 +47,7 @@ kube_addon_dir: /etc/kubernetes/addon
 # Additional feature to install
 additional_features:
   helm: false
-  nfs_dynamic: false
+  nfs_dynamic: true
   metric_server: false
   logging: false
   kube_state_metric: false
@@ -58,7 +58,7 @@ tmp_dir: /opt/k8s
 
 
 #Supported container_runtime('docker', 'containerd', 'crio')
-container_runtime: crio
+container_runtime: containerd
 
 #for setting admin.conf 
 k8s_config:

--- a/roles/infra/k8s-cluster/tasks/ec2-master.yml
+++ b/roles/infra/k8s-cluster/tasks/ec2-master.yml
@@ -15,7 +15,7 @@
                #!/bin/bash
                apt update -y
                apt install curl python-y
-               curl https://raw.githubusercontent.com/khann-adill/play-with-kubectl/master/kubernetes-installation/set-hostname-kmaster.sh | bash
+               curl https://raw.githubusercontent.com/khann-adill/kubernetes-ansible/kubernetes-version-bump/.script/set-hostname-kmaster.sh | bash
     state: "{{ ec2.master.vm_state }}"
     aws_access_key: "{{ access_key }}"
     aws_secret_key: "{{ secret_key }}"


### PR DESCRIPTION
Bump version to **v1.21.0**
But on this version CRIO is not supported yet. Need to wait some time for using v1.21.0 with CRIO.
[https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/](url)

<img width="945" alt="crio" src="https://user-images.githubusercontent.com/36574088/114698046-4370da00-9d3c-11eb-9c45-8d82be3d2a30.PNG">
